### PR TITLE
Assignment9 complete

### DIFF
--- a/aesd-char-driver/aesd_ioctl.h
+++ b/aesd-char-driver/aesd_ioctl.h
@@ -1,0 +1,46 @@
+/*
+ * aesd_ioctl.h
+ *
+ *  Created on: Oct 23, 2019
+ *      Author: Dan Walkes
+ *
+ *  @brief Definitins for the ioctl used on aesd char devices for assignment 9
+ */
+
+#ifndef AESD_IOCTL_H
+#define AESD_IOCTL_H
+
+#ifdef __KERNEL__
+#include <asm-generic/ioctl.h>
+#include <linux/types.h>
+#else
+#include <sys/ioctl.h>
+#include <stdint.h>
+#endif
+
+/**
+ * A structure to be passed by IOCTL from user space to kernel space, describing the type
+ * of seek performed on the aesdchar driver
+ */
+struct aesd_seekto {
+    /**
+     * The zero referenced write command to seek into
+     */
+    uint32_t write_cmd;
+    /**
+     * The zero referenced offset within the write
+     */
+    uint32_t write_cmd_offset;
+};
+
+// Pick an arbitrary unused value from https://github.com/torvalds/linux/blob/master/Documentation/ioctl/ioctl-number.rst
+#define AESD_IOC_MAGIC 0x16
+
+// Define a write command from the user point of view, use command number 1
+#define AESDCHAR_IOCSEEKTO _IOWR(AESD_IOC_MAGIC, 1, struct aesd_seekto)
+/**
+ * The maximum number of commands supported, used for bounds checking
+ */
+#define AESDCHAR_IOC_MAXNR 1
+
+#endif /* AESD_IOCTL_H */

--- a/aesd-char-driver/aesd_ioctl.h
+++ b/aesd-char-driver/aesd_ioctl.h
@@ -33,7 +33,7 @@ struct aesd_seekto {
     uint32_t write_cmd_offset;
 };
 
-// Pick an arbitrary unused value from https://github.com/torvalds/linux/blob/master/Documentation/ioctl/ioctl-number.rst
+// Pick an arbitrary unused value from https://github.com/torvalds/linux/blob/master/Documentation/userspace-api/ioctl/ioctl-number.rst
 #define AESD_IOC_MAGIC 0x16
 
 // Define a write command from the user point of view, use command number 1

--- a/aesd-char-driver/aesdchar.h
+++ b/aesd-char-driver/aesdchar.h
@@ -31,6 +31,7 @@ struct aesd_dev
      
     struct cdev cdev;     /* Char device structure      */
     struct aesd_circular_buffer *buffer;
+   // size_t total_circ_buff_size; //for fixed_size_llseek call
     struct mutex lock;
 };
 

--- a/aesd-char-driver/aesdchar.h
+++ b/aesd-char-driver/aesdchar.h
@@ -31,7 +31,6 @@ struct aesd_dev
      
     struct cdev cdev;     /* Char device structure      */
     struct aesd_circular_buffer *buffer;
-   // size_t total_circ_buff_size; //for fixed_size_llseek call
     struct mutex lock;
 };
 

--- a/aesd-char-driver/main.c
+++ b/aesd-char-driver/main.c
@@ -1,13 +1,12 @@
 /**
  * @file aesdchar.c
  * @brief Functions and data related to the AESD char driver implementation
- *
  * Based on the implementation of the "scull" device driver, found in
  * Linux Device Drivers example code.
  *
- * @author Dan Walkes
- * @date 2019-10-22
- * @copyright Copyright (c) 2019
+ * @author Dan Walkes, Visweshwaran Baskaran
+ * @date 2023-11-07
+ * @copyright Copyright (c) 2023
  *
  */
 #include <linux/slab.h>
@@ -16,19 +15,19 @@
 #include <linux/printk.h>
 #include <linux/types.h>
 #include <linux/cdev.h>
-#include <linux/fs.h> 
+#include <linux/fs.h>
 #include "aesdchar.h"
 #include "aesd-circular-buffer.h"
 #include "aesd_ioctl.h"
-int aesd_major =   0; // use dynamic major
-int aesd_minor =   0;
-char* final_buffptr = NULL;
 
-MODULE_AUTHOR("Visweshwaran Baskaran"); 
+int aesd_major = 0; // use dynamic major
+int aesd_minor = 0;
+char * final_buffptr = NULL;
+
+MODULE_AUTHOR("Visweshwaran Baskaran");
 MODULE_LICENSE("Dual BSD/GPL");
 
 struct aesd_dev aesd_device;
-
 
 /**
  * This function opens the AESD character device. It initializes
@@ -40,341 +39,353 @@ struct aesd_dev aesd_device;
  *
  * Based on scull_open() in scull/main.c
  */
-int aesd_open(struct inode *inode, struct file *filp)
-{
-    PDEBUG("open");
-    //Based on scull_open() in scull/main.c   
-    struct aesd_dev *dev;
-    dev = container_of(inode->i_cdev, struct aesd_dev, cdev);
-    filp->private_data = dev;
-    return 0;
+int aesd_open(struct inode * inode, struct file * filp) {
+  PDEBUG("open");
+  //Based on scull_open() in scull/main.c   
+  struct aesd_dev * dev;
+  dev = container_of(inode -> i_cdev, struct aesd_dev, cdev);
+  filp -> private_data = dev;
+  return 0;
 }
 
-int aesd_release(struct inode *inode, struct file *filp)
-{
-    PDEBUG("release"); 
-    // Nothing to add based on scull/main.c
-    return 0;
+/**
+ * This function is called when the last file descriptor referring to the
+ * device is closed.
+ * @param inode  Pointer to the inode structure for the device file.
+ * @param filp   Pointer to the file structure for the device file.
+ * @return       Returns 0 on success.
+ */
+int aesd_release(struct inode * inode, struct file * filp) {
+  PDEBUG("release");
+  // Nothing to add based on scull/main.c
+  return 0;
 }
 
-ssize_t aesd_read(struct file *filp, char __user *buf, size_t count,
-                loff_t *f_pos)
-{
-PDEBUG("In aesd_read\n");
-    ssize_t retval = 0;
-    PDEBUG("read %zu bytes with offset %lld",count,*f_pos);
-    ssize_t entry_offset = 0; 
-    if (!filp)
-    {
-    	PDEBUG("filp does not exist\n\r");
-        return -EFAULT; 
-    }
+/**
+ * aesd_read - Read data from the device
+ *
+ * This function is responsible for reading data from the device. It reads
+ * data from the circular buffer and copies it to the user-provided buffer.
+ *
+ * @param filp     Pointer to the file structure for the device file.
+ * @param buf      User-space buffer where the data will be copied.
+ * @param count    The maximum number of bytes to read.
+ * @param f_pos    Pointer to the file position offset.
+ * @return         Returns the number of bytes read on success, or a negative
+ *                 error code on failure.
+ */
+ssize_t aesd_read(struct file * filp, char __user * buf, size_t count,
+  loff_t * f_pos) {
+  PDEBUG("In aesd_read\n");
+  ssize_t retval = 0;
+  PDEBUG("read %zu bytes with offset %lld", count, * f_pos);
+  ssize_t entry_offset = 0;
+  if (!filp) {
+    PDEBUG("filp does not exist\n\r");
+    return -EFAULT;
+  }
 
-	mutex_lock_interruptible(&aesd_device.lock);
-	struct aesd_buffer_entry *read_entry = aesd_circular_buffer_find_entry_offset_for_fpos(aesd_device.buffer, (size_t)*f_pos, &entry_offset);
+  mutex_lock_interruptible( & aesd_device.lock);
+  struct aesd_buffer_entry * read_entry = aesd_circular_buffer_find_entry_offset_for_fpos(aesd_device.buffer, (size_t) * f_pos, & entry_offset);
 
-	if(read_entry == NULL) //checking if the buffer entry is found
-    	{
-    		PDEBUG("read_entry not found\n\r");
-        	mutex_unlock(&(aesd_device.lock));
-        	return retval;
-    	}
+  if (read_entry == NULL) //checking if the buffer entry is found
+  {
+    PDEBUG("read_entry not found\n\r");
+    mutex_unlock( & (aesd_device.lock));
+    return retval;
+  }
 
+  ssize_t bytes_to_read = read_entry -> size - entry_offset;
+  if (bytes_to_read < count)
+  ;
+  else
+    bytes_to_read = count;
 
- 	ssize_t bytes_to_read = read_entry->size - entry_offset;      
-        if (bytes_to_read < count)
-        ;
-        else
-            bytes_to_read = count;          
+  PDEBUG("buf copy: %s\n", read_entry -> buffptr + entry_offset);
+  if (copy_to_user(buf, read_entry -> buffptr + entry_offset, bytes_to_read) != 0) {
+    printk(KERN_ALERT "copy_to_user failed\n");
+    return -EFAULT;
+  } else {
+    PDEBUG("copy_to_user passed\r\n");
+  }
 
-	PDEBUG("buf copy: %s\n", read_entry->buffptr + entry_offset);
-        if (copy_to_user(buf, read_entry->buffptr + entry_offset, bytes_to_read) != 0) 
-        {
-             printk(KERN_ALERT "copy_to_user failed\n");
-             return -EFAULT;
-        } 
-        else
-        {
-        PDEBUG("copy_to_user passed\r\n");
-        }
-        
-        *f_pos += bytes_to_read;
-        retval = bytes_to_read;
+  * f_pos += bytes_to_read;
+  retval = bytes_to_read;
 
-    	mutex_unlock(&aesd_device.lock);
-    	return retval;
+  mutex_unlock( & aesd_device.lock);
+  return retval;
 }
 
-/*
-@reference: Code leveraged from Ashwin Ravindra's implementation of aesd_write
+/**
+ * aesd_write - Write data to the device
+ *
+ * This function is responsible for writing data to the device. It handles the
+ * buffering of data and copying it into the circular buffer for later reading.
+ *
+ * @param filp     Pointer to the file structure for the device file.
+ * @param buf      User-space buffer containing the data to be written.
+ * @param count    The number of bytes to write.
+ * @param f_pos    Pointer to the file position offset.
+ * @return         Returns the number of bytes written on success, or a negative
+ *                 error code on failure.
+ *@reference: Code leveraged from Ashwin Ravindra's implementation of aesd_write
 */
-ssize_t aesd_write(struct file *filp, const char __user *buf, size_t count,
-                loff_t *f_pos)
-{
-    PDEBUG("In aesd_write\n");
-    ssize_t retval = -ENOMEM;
-    PDEBUG("write %zu bytes with offset %lld",count,*f_pos);
-    static size_t final_count = 0;
-    //struct aesd_dev *dev = (struct aesd_dev*) filp->private_data;
-   
-    char *temp_buffptr = kmalloc(count, GFP_KERNEL);
-    if (!temp_buffptr)
-    {
+ssize_t aesd_write(struct file * filp,
+  const char __user * buf, size_t count,
+    loff_t * f_pos) {
+  PDEBUG("In aesd_write\n");
+  ssize_t retval = -ENOMEM;
+  PDEBUG("write %zu bytes with offset %lld", count, * f_pos);
+  static size_t final_count = 0;
+  char * temp_buffptr = kmalloc(count, GFP_KERNEL);
+  if (!temp_buffptr) {
     PDEBUG("temp_buffptr does not exist\n");
-        return retval;
-    }
-    //static char *final_buffptr = NULL;
-    if (!final_buffptr) 
-    {
+    return retval;
+  }
+  //static char *final_buffptr = NULL;
+  if (!final_buffptr) {
     PDEBUG("final_buffptr does not exist\n");
-            kfree(temp_buffptr);
-            return retval;
-    }
-    if (copy_from_user(temp_buffptr, buf, count) != 0) 
-    {
-    	PDEBUG("copy_from_user failed\n");
-        kfree(temp_buffptr);
-        return retval;
-    }
-     if(strchr(temp_buffptr, '\n') == NULL) {
-        final_buffptr = krealloc(final_buffptr, final_count + count, GFP_KERNEL); //realloc based on new size
-        memcpy(final_buffptr + final_count, temp_buffptr, count);
-        PDEBUG("final_buffptr: %s", final_buffptr);
-        final_count += count;
-        retval = count;
-        kfree(temp_buffptr); //this is not needed anymore
-        temp_buffptr = NULL; // Dont leave it dangling
-        return retval;
-    }
-
-    final_buffptr = krealloc(final_buffptr, final_count + count, GFP_KERNEL);
+    kfree(temp_buffptr);
+    return retval;
+  }
+  if (copy_from_user(temp_buffptr, buf, count) != 0) {
+    PDEBUG("copy_from_user failed\n");
+    kfree(temp_buffptr);
+    return retval;
+  }
+  if (strchr(temp_buffptr, '\n') == NULL) {
+    final_buffptr = krealloc(final_buffptr, final_count + count, GFP_KERNEL); //realloc based on new size
     memcpy(final_buffptr + final_count, temp_buffptr, count);
     PDEBUG("final_buffptr: %s", final_buffptr);
     final_count += count;
-    
-    struct aesd_buffer_entry *write_entry = kmalloc(sizeof(struct aesd_buffer_entry), GFP_KERNEL);
-    if (write_entry == NULL) 
-    {
-        retval = -ENOMEM;
-    }
-    else 
-    {
-        write_entry->size = final_count;
-        write_entry->buffptr = kmalloc(final_count, GFP_KERNEL);
-        memcpy(write_entry->buffptr, final_buffptr, final_count);
-
-       //mutex_lock(&dev->lock);
-       mutex_lock_interruptible(&aesd_device.lock);
-        const char* overwritten_buffptr = aesd_circular_buffer_add_entry(aesd_device.buffer, write_entry);
-
-  //aesd_device.total_circ_buff_size = write_entry->size;
-    //mutex_unlock(&dev->lock);
-    mutex_unlock(&aesd_device.lock);
-
-        /*If overwritten, free the overwritten entry*/
-        if(overwritten_buffptr != NULL) {
-            kfree(overwritten_buffptr);
-        }
-        retval = final_count;
-        final_count = 0;
-    }
-
- 
-	    
+    retval = count;
+    kfree(temp_buffptr); //this is not needed anymore
+    temp_buffptr = NULL; // Dont leave it dangling
     return retval;
+  }
+
+  final_buffptr = krealloc(final_buffptr, final_count + count, GFP_KERNEL);
+  memcpy(final_buffptr + final_count, temp_buffptr, count);
+  PDEBUG("final_buffptr: %s", final_buffptr);
+  final_count += count;
+
+  struct aesd_buffer_entry * write_entry = kmalloc(sizeof(struct aesd_buffer_entry), GFP_KERNEL);
+  if (write_entry == NULL) {
+    retval = -ENOMEM;
+  } else {
+    write_entry -> size = final_count;
+    write_entry -> buffptr = kmalloc(final_count, GFP_KERNEL);
+    memcpy(write_entry -> buffptr, final_buffptr, final_count);
+
+    //mutex_lock(&dev->lock);
+    mutex_lock_interruptible( & aesd_device.lock);
+    const char * overwritten_buffptr = aesd_circular_buffer_add_entry(aesd_device.buffer, write_entry);
+    mutex_unlock( & aesd_device.lock);
+
+    /*If overwritten, free the overwritten entry*/
+    if (overwritten_buffptr != NULL) {
+      kfree(overwritten_buffptr);
+    }
+    retval = final_count;
+    final_count = 0;
+  }
+
+  return retval;
 }
-
-loff_t aesd_llseek(struct file *filp, loff_t offset, int whence) {
-    PDEBUG("llseek");
-    if (filp == NULL)
-    {
-        return -EFAULT;
-    }
-    struct aesd_dev *dev = filp->private_data;
-    struct aesd_buffer_entry *iter_entry;
-    loff_t updated_offset = 0, size = 0;
-    int index = 0;
-    if (mutex_lock_interruptible(&dev->lock) != 0)
-    {
-        return -ERESTARTSYS;
-    }
-    AESD_CIRCULAR_BUFFER_FOREACH(iter_entry,aesd_device.buffer,index) 
-    {
-        size += iter_entry->size; 
-    }
-    updated_offset = fixed_size_llseek(filp, offset, whence, size);
-    PDEBUG("llseek to %lld",updated_offset);
-    mutex_unlock(&dev->lock);
-    return updated_offset;
-}
-
-
-
 
 /**
-* Adjust the file offset (f_pos) parameter of @param filp based on the location specified by
-* @param write cmd (the zero referenced command to locate)
-* and @param write_cmd_offset (the zero referenced offset into the command)
-* @return 0 if successful, negative if error occurred:
-* -ERESTARTSYS if mutex could not be obtained
-* -EINVAL if write command or write_cmd_offset was out of range
-*/
-static long aesd_adjust_file_offset(struct file *filp,unsigned int write_cmd, unsigned int write_cmd_offset)
-{
-	long retval = 0;
-	int i;
-	if (filp == NULL)
-    	{
-        return -EFAULT;
-    	}
-	struct aesd_dev *dev = filp->private_data;
-	
-	if(write_cmd > AESDCHAR_MAX_WRITE_OPERATIONS_SUPPORTED) //valid write_cmd value check
-	{
-        retval = -EINVAL;
-        return retval;
-    	}
-    	if (mutex_lock_interruptible(&dev->lock) != 0)
-	{
-		return -ERESTARTSYS;
-	}
-    	if(write_cmd_offset > dev->buffer->entry[write_cmd].size) //write_cmd_offset is >= size of command
-    	{
-        retval = -EINVAL;
-        return retval;
-    	}
-    
-    	for (i=0; i<write_cmd; i++)
-	{
-	   filp->f_pos += dev->buffer->entry[i].size;
-	}
-	filp->f_pos += write_cmd_offset;
-	retval = filp->f_pos;
-	mutex_unlock(&dev->lock);
-	return retval;
+ * aesd_llseek - Change the file position
+ *
+ * This function is responsible for changing the file position (seek) within
+ * the device file. It calculates the updated offset based on the given offset
+ * and whence parameters.
+ *
+ * @param filp   Pointer to the file structure for the device file.
+ * @param offset The new file position offset.
+ * @param whence The reference point for the offset (SEEK_SET, SEEK_CUR, SEEK_END).
+ * @return       Returns the updated file position offset on success, or a
+ *               negative error code on failure.
+ */
+loff_t aesd_llseek(struct file * filp, loff_t offset, int whence) {
+  PDEBUG("llseek");
+  if (filp == NULL) {
+    return -EFAULT;
+  }
+  struct aesd_dev * dev = filp -> private_data;
+  struct aesd_buffer_entry * iter_entry;
+  loff_t updated_offset = 0, size = 0;
+  int index = 0;
+  if (mutex_lock_interruptible( & dev -> lock) != 0) {
+    return -ERESTARTSYS;
+  }
+  AESD_CIRCULAR_BUFFER_FOREACH(iter_entry, aesd_device.buffer, index) {
+    size += iter_entry -> size;
+  }
+  updated_offset = fixed_size_llseek(filp, offset, whence, size);
+  PDEBUG("llseek to %lld", updated_offset);
+  mutex_unlock( & dev -> lock);
+  return updated_offset;
 }
 
-long aesd_ioctl(struct file *filp, unsigned int cmd, unsigned long arg) 
-{
-    PDEBUG("ioctl");	
-    long retval = 0;
-    if (filp == NULL)
-    {
-        return -EFAULT;
-    }
-    if (_IOC_NR(cmd) > AESDCHAR_IOC_MAXNR) //bounds checking
-    {
-	return -ENOTTY;
-    }
-    switch(cmd)
-    {
-    case AESDCHAR_IOCSEEKTO:
-    {
-        struct aesd_seekto seekto;
-        if(copy_from_user(&seekto, (const void*)arg, sizeof(seekto)) != 0) {
-            retval = EFAULT;
-        }
-        else {
-            retval = aesd_adjust_file_offset(filp, seekto.write_cmd, seekto.write_cmd_offset);
-        }
-        break;
-    }
-    } 
+/**
+ * Adjust the file offset (f_pos) parameter of @param filp based on the location specified by
+ * @param write cmd (the zero referenced command to locate)
+ * and @param write_cmd_offset (the zero referenced offset into the command)
+ * @return 0 if successful, negative if error occurred:
+ * -ERESTARTSYS if mutex could not be obtained
+ * -EINVAL if write command or write_cmd_offset was out of range
+ */
+static long aesd_adjust_file_offset(struct file * filp, unsigned int write_cmd, unsigned int write_cmd_offset) {
+  long retval = 0;
+  int i;
+  if (filp == NULL) {
+    return -EFAULT;
+  }
+  struct aesd_dev * dev = filp -> private_data;
+  if (mutex_lock_interruptible( & dev -> lock) != 0) {
+    return -ERESTARTSYS;
+  }
+  if (write_cmd > AESDCHAR_MAX_WRITE_OPERATIONS_SUPPORTED) //valid write_cmd value check
+  {
+    retval = -EINVAL;
+    mutex_unlock( & dev -> lock);
     return retval;
+  } else if (write_cmd_offset > dev -> buffer -> entry[write_cmd].size) //write_cmd_offset is >= size of command
+  {
+    retval = -EINVAL;
+    mutex_unlock( & dev -> lock);
+    return retval;
+  } else if (dev -> buffer -> entry[write_cmd].buffptr == NULL) {
+    retval = -EINVAL;
+    mutex_unlock( & dev -> lock);
+    return retval;
+  } else {
+    for (i = 0; i < write_cmd; i++) {
+      filp -> f_pos += dev -> buffer -> entry[i].size;
+    }
+    filp -> f_pos += write_cmd_offset;
+    retval = filp -> f_pos;
+  }
+  mutex_unlock( & dev -> lock);
+  return retval;
+}
+
+/**
+ * aesd_ioctl - Perform device-specific control operations
+ *
+ * This function is responsible for handling device-specific control operations
+ * (ioctl) for the device. It supports the `AESDCHAR_IOCSEEKTO` command for
+ * adjusting the file offset.
+ *
+ * @param filp Pointer to the file structure for the device file.
+ * @param cmd  The IOCTL command to perform.
+ * @param arg  An argument for the IOCTL command.
+ * @return     Returns 0 on success or a negative error code on failure.
+ */
+long aesd_ioctl(struct file * filp, unsigned int cmd, unsigned long arg) {
+  PDEBUG("ioctl");
+  long retval = 0;
+  if (filp == NULL) {
+    return -EFAULT;
+  }
+  if (_IOC_NR(cmd) > AESDCHAR_IOC_MAXNR) //bounds checking
+  {
+    return -ENOTTY;
+  }
+  switch (cmd) {
+  case AESDCHAR_IOCSEEKTO: {
+    struct aesd_seekto seekto;
+    if (copy_from_user( & seekto, (const void * ) arg, sizeof(seekto))) {
+      retval = EFAULT;
+    } else {
+      retval = aesd_adjust_file_offset(filp, seekto.write_cmd, seekto.write_cmd_offset);
+    }
+    break;
+  }
+  }
+  return retval;
 }
 struct file_operations aesd_fops = {
-    .owner =    THIS_MODULE,
-    .read =     aesd_read,
-    .write =    aesd_write,
-    .open =     aesd_open,
-    .release =  aesd_release,
-    .llseek =   aesd_llseek,
-    .unlocked_ioctl = aesd_ioctl,
+  .owner = THIS_MODULE,
+  .read = aesd_read,
+  .write = aesd_write,
+  .open = aesd_open,
+  .release = aesd_release,
+  .llseek = aesd_llseek,
+  .unlocked_ioctl = aesd_ioctl,
 };
 
-static int aesd_setup_cdev(struct aesd_dev *dev)
-{
-    int err, devno = MKDEV(aesd_major, aesd_minor);
+static int aesd_setup_cdev(struct aesd_dev * dev) {
+  int err, devno = MKDEV(aesd_major, aesd_minor);
 
-    cdev_init(&dev->cdev, &aesd_fops);
-    dev->cdev.owner = THIS_MODULE;
-    dev->cdev.ops = &aesd_fops;
-    err = cdev_add (&dev->cdev, devno, 1);
-    if (err) {
-        printk(KERN_ERR "Error %d adding aesd cdev", err);
-    }
-    return err;
+  cdev_init( & dev -> cdev, & aesd_fops);
+  dev -> cdev.owner = THIS_MODULE;
+  dev -> cdev.ops = & aesd_fops;
+  err = cdev_add( & dev -> cdev, devno, 1);
+  if (err) {
+    printk(KERN_ERR "Error %d adding aesd cdev", err);
+  }
+  return err;
 }
 
-
-int aesd_init_module(void)
-{
-    dev_t dev = 0;
-    int result;
-    result = alloc_chrdev_region(&dev, aesd_minor, 1,
-            "aesdchar");
-    aesd_major = MAJOR(dev);
-    if (result < 0) {
-        printk(KERN_WARNING "Can't get major %d\n", aesd_major);
-        return result;
-    }
-    memset(&aesd_device,0,sizeof(struct aesd_dev));
-    PDEBUG("Init AESD module");
-
-    struct aesd_circular_buffer* buffer = kmalloc(sizeof(struct aesd_circular_buffer), GFP_KERNEL);
-    aesd_device.buffer = buffer;
-    mutex_init(&aesd_device.lock); 
-    aesd_circular_buffer_init(aesd_device.buffer); //initialize the buffer
-    final_buffptr = kmalloc(4, GFP_KERNEL); 
-    
-    /**
-     * TODO: initialize the AESD specific portion of the device
-     */
-     
-    result = aesd_setup_cdev(&aesd_device);
-
-    if( result ) {
-        unregister_chrdev_region(dev, 1);
-    }
+int aesd_init_module(void) {
+  dev_t dev = 0;
+  int result;
+  result = alloc_chrdev_region( & dev, aesd_minor, 1,
+    "aesdchar");
+  aesd_major = MAJOR(dev);
+  if (result < 0) {
+    printk(KERN_WARNING "Can't get major %d\n", aesd_major);
     return result;
+  }
+  memset( & aesd_device, 0, sizeof(struct aesd_dev));
+  PDEBUG("Init AESD module");
+
+  struct aesd_circular_buffer * buffer = kmalloc(sizeof(struct aesd_circular_buffer), GFP_KERNEL);
+  aesd_device.buffer = buffer;
+  mutex_init( & aesd_device.lock);
+  aesd_circular_buffer_init(aesd_device.buffer); //initialize the buffer
+  final_buffptr = kmalloc(4, GFP_KERNEL);
+
+  /**
+   * TODO: initialize the AESD specific portion of the device
+   */
+
+  result = aesd_setup_cdev( & aesd_device);
+
+  if (result) {
+    unregister_chrdev_region(dev, 1);
+  }
+  return result;
 }
 
+void aesd_cleanup_module(void) {
+  dev_t devno = MKDEV(aesd_major, aesd_minor);
 
-void aesd_cleanup_module(void)
-{
-    dev_t devno = MKDEV(aesd_major, aesd_minor);
+  cdev_del( & aesd_device.cdev);
 
-    cdev_del(&aesd_device.cdev);
-
-
-
-	struct aesd_buffer_entry* cleanup_entry;
-    uint8_t index;
-    AESD_CIRCULAR_BUFFER_FOREACH(cleanup_entry, aesd_device.buffer, index) 
-    {
-    	if(cleanup_entry->buffptr != NULL)
-    	{
-        kfree(cleanup_entry->buffptr);
-        PDEBUG("Entry freed\n");
-        }
+  struct aesd_buffer_entry * cleanup_entry;
+  uint8_t index;
+  AESD_CIRCULAR_BUFFER_FOREACH(cleanup_entry, aesd_device.buffer, index) {
+    if (cleanup_entry -> buffptr != NULL) {
+      kfree(cleanup_entry -> buffptr);
+      PDEBUG("Entry freed\n");
     }
+  }
 
-  
- if (aesd_device.buffer != NULL)
-    {
-        kfree(aesd_device.buffer);
-        PDEBUG("aesd_device.buffer freed\n");
-    }
+  if (aesd_device.buffer != NULL) {
+    kfree(aesd_device.buffer);
+    PDEBUG("aesd_device.buffer freed\n");
+  }
 
-    // Assuming final_buffptr is a pointer, add a null check
-    if (final_buffptr != NULL)
-    {
-        kfree(final_buffptr);
-        PDEBUG("final_buffptr freed\n");
-    }
+  // Assuming final_buffptr is a pointer, add a null check
+  if (final_buffptr != NULL) {
+    kfree(final_buffptr);
+    PDEBUG("final_buffptr freed\n");
+  }
 
-    mutex_destroy(&aesd_device.lock);
-    unregister_chrdev_region(devno, 1);
+  mutex_destroy( & aesd_device.lock);
+  unregister_chrdev_region(devno, 1);
 }
 
 module_init(aesd_init_module);

--- a/conf/assignment.txt
+++ b/conf/assignment.txt
@@ -1,1 +1,1 @@
-assignment8
+assignment9


### PR DESCRIPTION
Test run at https://github.com/cu-ecen-aeld/assignment-9-VisweshBaskaran/actions/runs/6794655512/job/18471403702 crashing as below despite indicating success status
```
2023-11-08T06:52:32.9281778Z aesdchar: open
2023-11-08T06:52:32.9282345Z aesdchar: In aesd_write
2023-11-08T06:52:32.9283127Z aesdchar: write 0 bytes with offset 0
2023-11-08T06:52:32.9284256Z Unable to handle kernel NULL pointer dereference at virtual address 0000000000000010
2023-11-08T06:52:32.9285158Z Mem aSending ioc seekto command for offset 8,6
2023-11-08T06:52:32.9286292Z bort info:
2023-11-08T06:52:32.9286806Z   ESR = 0x96000005
2023-11-08T06:52:32.9287326Z   EC = 0x25: DABT (current EL), IL = 32 bits
2023-11-08T06:52:32.9287938Z   SET = 0, FnV = 0
2023-11-08T06:52:32.9288410Z   EA = 0, S1PTW = 0
2023-11-08T06:52:32.9291321Z   FSC = 0x05: level 1 translation fault
2023-11-08T06:52:32.9293570Z Data abort info:
2023-11-08T06:52:32.9295777Z   ISV = 0, ISS = 0x00000005
2023-11-08T06:52:32.9300163Z   CM = 0, WnR = 0
2023-11-08T06:52:32.9317355Z user pgtable: 4k pages, 39-bit VAs, pgdp=0000000042116000
2023-11-08T06:52:32.9325269Z [0000000000000010] pgd=0000000000000000, p4d=0000000000000000, pud=0000000000000000
2023-11-08T06:52:32.9329516Z Internal error: Oops: 96000005 [#11] SMP
2023-11-08T06:52:32.9338779Z Modules linked in: aesdchar(O) hello(O) scull(O) faulty(O) [last unloaded: aesdchar]
2023-11-08T06:52:32.9347037Z CPU: 0 PID: 218 Comm: aesdsocket Tainted: G      D    O      5.15.18 #1
2023-11-08T06:52:32.9348102Z Hardware name: linux,dummy-virt (DT)
2023-11-08T06:52:32.9355857Z pstate: 80000005 (Nzcv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
2023-11-08T06:52:32.9358156Z pc : strchr+0x8/0x38
2023-11-08T06:52:32.9362436Z lr : aesd_write+0xdc/0x200 [aesdchar]
2023-11-08T06:52:32.9363676Z sp : ffffffc008c8bd50
2023-11-08T06:52:32.9373091Z x29: ffffffc008c8bd50 x28: ffffff80020ecc80 x27: 0000000000000000
2023-11-08T06:52:32.9377340Z x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000000
2023-11-08T06:52:32.9387420Z x23: 0000000080001000 x22: 000000556f75fc50 x21: 0000000000000010
2023-11-08T06:52:32.9390526Z x20: 0000000000000000 x19: ffffffc000708400 x18: 0000000000000020
2023-11-08T06:52:32.9396675Z x17: 0000000000000000 x16: 0000000000000000 x15: 000000556f75fc50
2023-11-08T06:52:32.9403908Z x14: ffffffc008a6d530 x13: 302074657366666f x12: ffffffc00899b9c0
2023-11-08T06:52:32.9411565Z x11: 000000000000054c x10: 0000000000000058 x9 : 00000000ffffefff
2023-11-08T06:52:32.9417971Z x8 : ffffffc0089f39c0 x7 : 0000000000017fe8 x6 : 0000000000000010
2023-11-08T06:52:32.9424698Z x5 : 0000000000000010 x4 : 000000556f75fc50 x3 : 0000000000400040
2023-11-08T06:52:32.9430517Z x2 : 0000000000000000 x1 : 000000000000000a x0 : 0000000000000010
2023-11-08T06:52:32.9432456Z Call trace:
2023-11-08T06:52:32.9433738Z  strchr+0x8/0x38
2023-11-08T06:52:32.9436004Z  vfs_write+0xa8/0x2b0
2023-11-08T06:52:32.9439379Z  ksys_write+0x68/0x100
2023-11-08T06:52:32.9442175Z  __arm64_sys_write+0x20/0x30
2023-11-08T06:52:32.9444955Z  invoke_syscall+0x54/0x130
2023-11-08T06:52:32.9449450Z  el0_svc_common.constprop.0+0x44/0xf0
2023-11-08T06:52:32.9451959Z  do_el0_svc+0x40/0xa0
2023-11-08T06:52:32.9453735Z  el0_svc+0x20/0x60
2023-11-08T06:52:32.9457415Z  el0t_64_sync_handler+0xe8/0xf0
2023-11-08T06:52:32.9459795Z  el0t_64_sync+0x1a0/0x1a4
2023-11-08T06:52:32.9466692Z Code: 54fff701 d65f03c0 d503245f 12001c21 (38401402) 
2023-11-08T06:52:32.9468955Z ---[ end trace 13a480e7739a65a4 ]---
2023-11-08T06:52:32.9682706Z aesdchar: open
2023-11-08T06:52:32.9686466Z aesdchar: ioctl
2023-11-08T06:52:32.9688056Z aesdchar: In aesd_read
2023-11-08T06:52:32.9694663Z aesdchar: read 30000 bytes with offset 70
2023-11-08T06:52:32.9695277Z aesdchar: buf copy: 9
2023-11-08T06:52:32.9696791Z 
2023-11-08T06:52:32.9697959Z aesdchar: copy_to_user passed
2023-11-08T06:52:32.9698381Z 
2023-11-08T06:52:32.9705175Z aesdchar: In aesd_read
2023-11-08T06:52:32.9711793Z aesdchar: read 30000 bytes with offset 72
2023-11-08T06:52:32.9716990Z aesdchar: buf copy: swrite10
2023-11-08T06:52:32.9717685Z 
2023-11-08T06:52:32.9720177Z aesdchar: copy_to_user passed
2023-11-08T06:52:32.9721119Z 
2023-11-08T06:52:32.9761152Z aesdchar: In aesd_read
2023-11-08T06:52:32.9765130Z aesdchar: read 30000 bytes with offset 81
2023-11-08T06:52:33.9792933Z aesdchar:9
2023-11-08T06:52:33.9793506Z swrite10
2023-11-08T06:52:33.9793978Z  read_entry not found
2023-11-08T06:52:33.9794582Z 
2023-11-08T06:52:33.9794657Z 
2023-11-08T06:52:33.9808427Z aesdchar: open
2023-11-08T06:52:33.9809575Z aesdchar: In aesd_writeTest passed
2023-11-08T06:52:33.9810212Z 
2023-11-08T06:52:33.9816408Z aesdchar: write 0 bytes with offKilling qemu
2023-11-08T06:52:33.9817087Z set 0
2023-11-08T06:52:33.9817814Z Unable to handle kernel NULL pointer dereference at virtual address 0000000000000010
2023-11-08T06:52:33.9818708Z Mem abort info:
2023-11-08T06:52:33.9819185Z   ESR = 0x96000005
2023-11-08T06:52:33.9824292Z   EC = 0x25: DABT (current EL), IL = 32 bits
2023-11-08T06:52:33.9824890Z   SET = 0, FnV = 0
2023-11-08T06:52:33.9826616Z   EA = 0, S1PTW = 0
2023-11-08T06:52:33.9831905Z   FSC = 0x05: level 1 translation fault
2023-11-08T06:52:33.9836567Z /__w/assignment-9-VisweshBaskaran/assignment-9-VisweshBaskaran/assignment-autotest/test/assignment9-buildroot
2023-11-08T06:52:33.9838470Z qemu-system-aarch64: terminating on signal 15 from pid 421409 (<unknown process>)
2023-11-08T06:52:33.9842487Z Test of assignment assignment9-buildroot complete with success
2023-11-08T06:52:34.0720093Z ##[group]Run ssh-add -D
2023-11-08T06:52:34.0720641Z [36;1mssh-add -D[0m
2023-11-08T06:52:34.0721325Z shell: sh -e {0}
```